### PR TITLE
CI Docker Builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,67 @@
+name: Release
+
+on:
+  release:
+    types: [created, edited]
+
+jobs:
+  release-docker:
+    name: Build and Publish Docker Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Extract Tag Name
+        shell: bash
+        run: echo "##[set-output name=tag;]$(echo ${GITHUB_REF#refs/tags/})"
+        id: extract_tag
+      - name: Extract Repo Owner
+        shell: bash
+        run: echo "##[set-output name=owner;]$(echo ${GITHUB_REPOSITORY%%/*} | tr '[:upper:]' '[:lower:]')"
+        id: extract_owner
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+      - name: Build and Push Base Image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: util/docker/Dockerfile.base
+          platforms: linux/amd64,linux/386,linux/arm64/v8
+          push: true
+          tags: ghcr.io/${{ steps.extract_owner.outputs.owner }}/mininet:base-${{ steps.extract_tag.outputs.tag }}
+          no-cache: false
+          labels: |
+            org.opencontainers.image.title=${{ github.event.repository.name }}
+            org.opencontainers.image.url=${{ github.event.repository.html_url }}
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
+      - name: Build and Push MN
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: util/docker/Dockerfile.mn
+          platforms: linux/amd64,linux/386,linux/arm64/v8
+          push: true
+          tags: |
+            ghcr.io/${{ steps.extract_owner.outputs.owner }}/mininet:${{ steps.extract_tag.outputs.tag }}
+            ghcr.io/${{ steps.extract_owner.outputs.owner }}/mn:${{ steps.extract_tag.outputs.tag }}
+          no-cache: false
+          build-args: |
+            REGISTRY=ghcr.io
+            REG_USER=${{ steps.extract_owner.outputs.owner }}
+            BASE_VERSION=${{ steps.extract_tag.outputs.tag }}
+          labels: |
+            org.opencontainers.image.title=${{ github.event.repository.name }}
+            org.opencontainers.image.url=${{ github.event.repository.html_url }}
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}

--- a/.github/workflows/rolling.yaml
+++ b/.github/workflows/rolling.yaml
@@ -1,0 +1,63 @@
+name: Rolling Release
+
+on:
+  push:
+    branches: [master, main]
+
+jobs:
+  rolling-docker:
+    name: Build and Publish Rolling Docker Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Extract Repo Owner
+        shell: bash
+        run: echo "##[set-output name=owner;]$(echo ${GITHUB_REPOSITORY%%/*} | tr '[:upper:]' '[:lower:]')"
+        id: extract_owner
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+      - name: Build and Push Base Image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: util/docker/Dockerfile.base
+          platforms: linux/amd64,linux/386,linux/arm64/v8
+          push: true
+          tags: ghcr.io/${{ steps.extract_owner.outputs.owner }}/mininet:base-latest
+          no-cache: false
+          labels: |
+            org.opencontainers.image.title=${{ github.event.repository.name }}
+            org.opencontainers.image.url=${{ github.event.repository.html_url }}
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
+      - name: Build and Push MN
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: util/docker/Dockerfile.mn
+          platforms: linux/amd64,linux/386,linux/arm64/v8
+          push: true
+          tags: |
+            ghcr.io/${{ steps.extract_owner.outputs.owner }}/mininet:latest
+            ghcr.io/${{ steps.extract_owner.outputs.owner }}/mn:latest
+          no-cache: false
+          build-args: |
+            REGISTRY=ghcr.io
+            REG_USER=${{ steps.extract_owner.outputs.owner }}
+            BASE_VERSION=latest
+          labels: |
+            org.opencontainers.image.title=${{ github.event.repository.name }}
+            org.opencontainers.image.url=${{ github.event.repository.html_url }}
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}


### PR DESCRIPTION
## Why?

Much like the Dockerfile PR, this isn't new but does aide development for the libvirt project. 

## What?

This builds and publishes docker images for mininet to the ghcr on a release or push to the master.