### PR TITLE
Mininet REST API

### DIFF
--- a/bin/mn
+++ b/bin/mn
@@ -27,6 +27,7 @@ if 'PYTHONPATH' in os.environ:
 
 from mininet.clean import cleanup
 import mininet.cli
+import mininet.rest
 from mininet.log import lg, LEVELS, info, debug, warn, error, output
 from mininet.net import Mininet, MininetWithControlNet, VERSION
 from mininet.node import ( Host, CPULimitedHost, Controller, OVSController,
@@ -97,6 +98,7 @@ TESTS = { name: True
           for name in ( 'pingall', 'pingpair', 'iperf', 'iperfudp' ) }
 
 CLI = None  # Set below if needed
+REST = None
 
 # Locally defined tests
 def allTest( net ):
@@ -299,7 +301,8 @@ class MininetRunner( object ):
                          metavar='block|random',
                          help=( 'node placement for --cluster '
                                 '(experimental!) ' ) )
-
+        opts.add_option( '--rest', action='store_true',
+                         default=False, help='Run a REST API for node interaction' )
         self.options, self.args = opts.parse_args()
 
         # We don't accept extra arguments after the options
@@ -324,7 +327,7 @@ class MininetRunner( object ):
     def begin( self ):
         "Create and run mininet."
 
-        global CLI
+        global CLI, REST
 
         opts = self.options
 
@@ -398,7 +401,7 @@ class MininetRunner( object ):
                   xterms=opts.xterms, autoSetMacs=opts.mac,
                   autoStaticArp=opts.arp, autoPinCpus=opts.pin,
                   waitConnected=opts.wait,
-                  listenPort=opts.listenport )
+                  listenPort=opts.listenport, rest=opts.rest )
 
         if opts.ensure_value( 'nat', False ):
             with open( '/etc/resolv.conf' ) as f:
@@ -414,6 +417,10 @@ class MininetRunner( object ):
             CLI( mn, script=opts.pre )
 
         mn.start()
+
+        if opts.rest:
+            REST = mininet.rest.REST if REST is None else REST
+            REST( mn )
 
         if opts.test:
             runTests( mn, opts.test )

--- a/mininet/net.py
+++ b/mininet/net.py
@@ -98,6 +98,7 @@ from itertools import chain, groupby
 from math import ceil
 
 from mininet.cli import CLI
+from mininet.rest import REST
 from mininet.log import info, error, debug, output, warn
 from mininet.node import ( Node, Host, OVSKernelSwitch, DefaultController,
                            Controller )
@@ -120,7 +121,7 @@ class Mininet( object ):
                   build=True, xterms=False, cleanup=False, ipBase='10.0.0.0/8',
                   inNamespace=False,
                   autoSetMacs=False, autoStaticArp=False, autoPinCpus=False,
-                  listenPort=None, waitConnected=False ):
+                  listenPort=None, waitConnected=False, rest=False ):
         """Create Mininet object.
            topo: Topo (topology) object or None
            switch: default Switch class
@@ -161,6 +162,7 @@ class Mininet( object ):
         self.nextCore = 0  # next core for pinning hosts to CPUs
         self.listenPort = listenPort
         self.waitConn = waitConnected
+        self.rest = rest
 
         self.hosts = []
         self.switches = []
@@ -921,6 +923,8 @@ class Mininet( object ):
     def interact( self ):
         "Start network and run our simple CLI."
         self.start()
+        if self.rest:
+            api = REST( self )
         result = CLI( self )
         self.stop()
         return result

--- a/mininet/rest.py
+++ b/mininet/rest.py
@@ -1,0 +1,102 @@
+"""
+A simple rest api interface for Mininet.
+
+The Mininet REST API provides a selection of endpoints
+that enable interaction with an instantated topology.
+
+curl ...
+
+runs 'ifconfig' on host h27.
+
+The REST API automatically substitutes IP addresses for node names,
+so commands like
+
+curl ...
+
+should work correctly and allow host h2 to ping host h3
+"""
+
+import threading
+import json
+import os.path
+
+from bottle import Bottle, HTTPResponse, request
+
+from mininet.log import info, output
+from mininet.log import error as mnerror
+
+# TODO: Add common error handlers
+# TODO: Graceful exit
+# TODO: Custom command endpoint
+
+
+class REST(Bottle):
+    "Simple REST API to talk to nodes."
+
+    prefix = '/mn/api'
+
+    def __init__(self, mininet, port=8080, **kwargs):
+        """Start and run interactive REST API
+           mininet: Mininet network object
+           port: port to expose the API"""
+        super(REST, self).__init__()
+        self.mn = mininet
+        if port > 65536 or port < 1:
+            mnerror('given port value is not valid for the api\n')
+            return
+        thread = threading.Thread(
+            target=self.run_server, args=(port,), daemon=True)
+        thread.start()
+        info('*** Running API\n')
+
+    def run_server(self, port):
+        self.route(self.prefix+'/nodes', callback=self.__getNodes)
+        self.route(self.prefix+'/stop', callback=self.__stop)
+        self.route(self.prefix+'/pingpair', callback=self.__pingPair)
+
+        try:
+            self.run(host='0.0.0.0', port=port, quiet=True)
+        except Exception as e:
+            print(e)
+            mnerror('Failed to start REST API\n')
+
+    def __build_response(self, data, code=200):
+        if not isinstance(data, dict):
+            data = json.dumps({"error": "could not create json response"})
+            return HTTPResponse(status=500, body=data)
+        return HTTPResponse(status=code, body=data)
+
+    def __stop(self):
+        self.mn.stop()
+        self.close()
+        return self.__build_response({"success": "stopping network"})
+
+    def __getNodes(self):
+        """Get a list of nodes that exist within a topo"""
+        data = {"nodes": [node for node in self.mn]}
+        return self.__build_response(data)
+
+    def __pingPair(self):
+        a = request.query.host_a
+        b = request.query.host_b
+        if a == '' or b == '':
+            data = {"error": "two hosts (host_a, host_b) must be given"}
+            return self.__build_response(data, code=400)
+        if not self.mn.get(a, b):
+            data = {"error": "non-existent host given"}
+            return self.__build_response(data, code=400)
+        hosts = self.mn.get(a, b)
+        results = self.mn.pingFull(hosts=hosts)
+        data = {
+            results[0][0].name: {
+                "destination": results[0][1].name,
+                "sent": results[0][2][0],
+                "received": results[0][2][1]
+            },
+            results[1][0].name: {
+                "destination": results[1][1].name,
+                "sent": results[1][2][0],
+                "received": results[1][2][1]
+            }
+        }
+        return self.__build_response(data, code=200)

--- a/util/install.sh
+++ b/util/install.sh
@@ -165,13 +165,13 @@ function mn_deps {
         $install gcc make socat psmisc xterm openssh-clients iperf \
             iproute telnet python-setuptools libcgroup-tools \
             ethtool help2man net-tools
-        $install ${PYPKG}-pyflakes pylint ${PYPKG}-pep8-naming  \
+        $install ${PYPKG}-bottle ${PYPKG}-pyflakes pylint ${PYPKG}-pep8-naming  \
             ${PYPKG}-pexpect
     elif [ "$DIST" = "SUSE LINUX"  ]; then
 		$install gcc make socat psmisc xterm openssh iperf \
 			iproute telnet ${PYPKG}-setuptools libcgroup-tools \
 			ethtool help2man python-pyflakes python3-pylint \
-                        python-pep8 ${PYPKG}-pexpect ${PYPKG}-tk
+                        python-pep8 ${PYPKG}-bottle ${PYPKG}-pexpect ${PYPKG}-tk
     else  # Debian/Ubuntu
         pf=pyflakes
         # Starting around 20.04, installing pyflakes instead of pyflakes3
@@ -182,7 +182,7 @@ function mn_deps {
         $install gcc make socat psmisc xterm ssh iperf telnet \
                  ethtool help2man $pf pylint pep8 \
                  net-tools \
-                 ${PYPKG}-pexpect ${PYPKG}-tk
+                 ${PYPKG}-bottle ${PYPKG}-pexpect ${PYPKG}-tk
         # Install pip
         $install ${PYPKG}-pip || $install ${PYPKG}-pip-whl
         if ! ${PYTHON} -m pip -V; then


### PR DESCRIPTION
Add a REST API into mininet.

## Why

Allows for interaction with mininet nodes without needing to use the mn CLI or requiring more code be added to each topology. Also allows for API usage using the `mn` command line tool.

## Documentation

For more info, see [here](https://wiki.ng-cdi.com/netdevops/mininet-rest-api/)