### PR TITLE
Add support for dynamips nodes

### DIFF
--- a/mtv/log.py
+++ b/mtv/log.py
@@ -4,6 +4,7 @@ import logging, time
 from logging import Logger
 from datetime import datetime
 import types
+from pathlib import Path
 
 
 # Create a new loglevel, 'CLI info', which enables a Mininet user to see only
@@ -166,6 +167,7 @@ def makeListCompatible(fn):
 def metric( desc,  message="" ):
     if METRICS != True:
         return
+    Path(METRICFILE).parent.mkdir(parents=True, exist_ok=True)
     with open(METRICFILE, 'a+') as f:
         text = f.read()
         if not text.endswith( '\n' ):

--- a/util/docker/Dockerfile
+++ b/util/docker/Dockerfile
@@ -6,28 +6,31 @@ FROM ${OPENFLOW_IMAGE} as openflow
 
 FROM debian:stretch-slim
 
-RUN apt-get update -q && \
-  apt-get install --no-install-recommends -yq \
-  arping \
-  hping3 \
-  iproute2 \
-  iputils-ping \
-  net-tools \
-  openvswitch-common \ 
-  openvswitch-switch \ 
-  openvswitch-testcontroller \
-  python3 \
-  python3-bottle \
-  python3-pip \
-  python3-setuptools \
-  telnet \
-  python-libvirt \
-  python3-libvirt \
-  virtinst \
-  libvirt-clients \
-  dnsmasq \
-  traceroute && \
-  rm -rf /var/lib/apt/lists/*
+RUN sed -i -e's/ main/ main contrib non-free/g' /etc/apt/sources.list && \
+    apt-get update -q && \
+    apt-get install --no-install-recommends -yq \
+    dynamips \
+    libpcap0.8 \
+    arping \
+    hping3 \
+    iproute2 \
+    iputils-ping \
+    net-tools \
+    openvswitch-common \
+    openvswitch-switch \
+    openvswitch-testcontroller \
+    python3 \
+    python3-bottle \
+    python3-pip \
+    python3-setuptools \
+    telnet \
+    python-libvirt \
+    python3-libvirt \
+    virtinst \
+    libvirt-clients \
+    dnsmasq \
+    traceroute && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY --from=openflow /usr/local/bin/ /usr/local/bin/
 COPY --from=mnexec /build/mnexec /usr/bin/mnexec

--- a/util/docker/entrypoint.sh
+++ b/util/docker/entrypoint.sh
@@ -35,8 +35,9 @@ if [ ! -z ${SCRIPT+x} ]; then
   becho "*** Running mininet via the Python API..."
   echo "*** Ignoring any command line flags"
   python3 $SCRIPT && clean_exit 0
+else
+  # Run MN with MN_FLAGS
+  becho "*** Running mininet using mn - flags: '$@'"
+  mn $@ && clean_exit 0
 fi
 
-# Run MN with MN_FLAGS
-becho "*** Running mininet using mn - flags: '$@'"
-mn $@ && clean_exit 0


### PR DESCRIPTION
I'm not entirely sure what you'd like the interface to be, but this works.

Example usage:

```py
from mtv.net import Mininet
from mtv.node import DynamipsRouter
from mtv.cli import CLI
from mtv.rest import REST

net = Mininet()

def dynamips_args(id: int):
    return dict(
        dynamips_platform="7200", 
        dynamips_port_driver=("PA-FE-TX", "FastEthernet", 1),
        # dynamips_image can be either a file path (str), or a file like object holding the image
        dynamips_image="/c7200-adventerprisek9-mz.152-4.M7.bin", 
        dynamips_args=[f"-i {id}", "--idle-pc=0x619d25bc", "-P 7200", "-o 64", "-r 256"])

c1 = net.addController('c1')

r1 = net.addSwitch('r1', cls=DynamipsRouter, **dynamips_args(0))

h1 = net.addHost('h1', ip="10.1.0.2/24", defaultRoute='via 10.1.0.1')
h2 = net.addHost('h2', ip="10.2.0.2/24", defaultRoute='via 10.2.0.1')

net.addLink(h1, r1, params2={"ip": "10.1.0.1/24"})
net.addLink(h2, r1, params2={"ip": "10.2.0.1/24"})

print("Initialising")
net.start()
print("Waiting for router(s) to start up")
net.waitConnected()

CLI(net)
net.stop()
```